### PR TITLE
fix(installation): switch to new compose docker plugin

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -4,11 +4,11 @@ The Docker installation is the method to choose if you want to quickly deploy Op
 
 ## Requirements ##
 
-The current documentation has been tested on **Debian 10** and **Ubuntu LTS 20.04** with the following requirements :
+The current documentation has been tested on **Debian 10**, **Rocky Linux 9** and **Ubuntu LTS 20.04** with the following requirements :
 
 <ul>
-<li>Docker-compose 1.21.0+</li>
-<li>Docker 20.10.1+</li>
+<li>Docker Compose v2.27.0</li>
+<li>Docker 26.1.1</li>
 <li>5 GB RAM</li>
 </ul>
 
@@ -34,7 +34,7 @@ Update the following keys in the `opencve.cfg` file:
 - smtp_user & smtp_password if any or leave empty
 
 !!!tip
-    If you want to change the default postgresql password (strongly advised), you can add it in the `.env` file before the docker-compose build:
+    If you want to change the default postgresql password (strongly advised), you can add it in the `.env` file before the docker compose build:
 
     ```
     POSTGRES_PASSWORD=MyStrongPassword42
@@ -51,13 +51,13 @@ Update the following keys in the `opencve.cfg` file:
 You can now build the OpenCVE image:
 
 ```
-$ docker-compose build
+$ docker compose build
 ```
 
 Then start everything except the beat:
 
 ```
-$ docker-compose up -d postgres redis webserver celery_worker
+$ docker compose up -d postgres redis webserver celery_worker
 ```
 
 ## Initialize the database ##
@@ -104,7 +104,7 @@ Repeat for confirmation:
 The last step is to start the scheduler :
 
 ```
-$ docker-compose up -d celery_beat
+$ docker compose up -d celery_beat
 ```
 
 You can now use OpenCVE with your own dockerized instance of it.


### PR DESCRIPTION
In new installations, `docker-compose` is deprecated and must be replaced by `docker compose`.